### PR TITLE
Add support for HTTPS

### DIFF
--- a/wpGoogleMaps.php
+++ b/wpGoogleMaps.php
@@ -6199,7 +6199,7 @@ function wpgmza_load_google_maps_api(){
             $wpgmza_api_key = get_option( 'wpgmza_google_maps_api_key' );
 
             if( $wpgmza_api_key ){
-                wp_enqueue_script('wpgmza_api_call', 'http://maps.google'.$wpgmza_suffix.'/maps/api/js?'.$api_version_string.'key='.$wpgmza_api_key.'&language='.$wpgmza_locale, array(), null );            
+                wp_enqueue_script('wpgmza_api_call', '//maps.google'.$wpgmza_suffix.'/maps/api/js?'.$api_version_string.'key='.$wpgmza_api_key.'&language='.$wpgmza_locale, array(), null );            
             } else {
                 wp_enqueue_script('wpgmza_api_call', '//maps.google'.$wpgmza_suffix.'/maps/api/js?'.$api_version_string.'language='.$wpgmza_locale, array(), null );            
             }


### PR DESCRIPTION
Instead of hard coding http, I suggest to use // instead. When a web page is loaded over https, there is no Google Maps loaded as http requests are blocked.