### PR TITLE
Spelling & Localization

### DIFF
--- a/html/gdpr-compliance-settings.html.php
+++ b/html/gdpr-compliance-settings.html.php
@@ -1,6 +1,6 @@
 <div id="wpgmza-gdpr-compliance">
 	<h2>
-		<?php _e('General Complicance', 'wp-google-maps'); ?>
+		<?php _e('General Compliance', 'wp-google-maps'); ?>
 	</h2>
 	
 	<fieldset>
@@ -63,7 +63,7 @@
 			_e('Require consent before load', 'wp-google-maps');
 			?>
 			<i class="fa fa-question-circle" 
-				title="<?php _e('The GDPR views IP Addresses as Personal Data, which requires consent before being processed. Loading the Google Maps API stores some user information, such as IP Addresses. WP Google Maps endeavours to uphold the spirit of data protection as per the GDPR. Enable this to option to prevent the Maps API from loading, until a user has consented to it.', 'wp-google-maps'); ?>"/>
+				title="<?php _e('The GDPR views IP Addresses as Personal Data, which requires consent before being processed. Loading the Google Maps API stores some user information, such as IP Addresses. WP Google Maps endeavors to uphold the spirit of data protection as per the GDPR. Enable this to option to prevent the Maps API from loading, until a user has consented to it.', 'wp-google-maps'); ?>"/>
 		</label>
 		<input name="wpgmza_gdpr_require_consent_before_load" type="checkbox"/>
 	</fieldset>


### PR DESCRIPTION
1. endeavours should be endeavors
As WP is en_US base localized should use endeavors so Glossaries pick up and on en_CA, en_GB, etc can translate
Permalink - https://translate.wordpress.org/projects/wp-plugins/wp-google-maps/dev/en-ca/default?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=6328378&filters%5Btranslation_id%5D=56105886

2. Complicance should be Compliance
Permalink - https://translate.wordpress.org/projects/wp-plugins/wp-google-maps/dev/en-ca/default?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=6328376&filters%5Btranslation_id%5D=56105835