### PR TITLE
Critical error fixed due to require_once() call with wrong path

### DIFF
--- a/includes/class.dom-element.php
+++ b/includes/class.dom-element.php
@@ -5,7 +5,7 @@ namespace WPGMZA;
 if(!defined('ABSPATH'))
 	return;
 
-require_once(plugin_dir_path(__FILE__) . '../class.selector-to-xpath.php');
+require_once(plugin_dir_path(__FILE__) . 'class.selector-to-xpath.php');
 
 /**
  * Direct replacement for the defauly class.dom-element.php


### PR DESCRIPTION
Wordpress Plugin Support Thread:
https://wordpress.org/support/topic/invalid-require_once-call/